### PR TITLE
RINGUS-53 feat: 세션검증을 담당할 어노테이션 기능 구현

### DIFF
--- a/src/main/java/es/princip/ringus/global/annotation/SessionCheck.java
+++ b/src/main/java/es/princip/ringus/global/annotation/SessionCheck.java
@@ -1,0 +1,12 @@
+package es.princip.ringus.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SessionCheck {
+    boolean required() default true;
+}

--- a/src/main/java/es/princip/ringus/global/interceptor/SessionInterceptor.java
+++ b/src/main/java/es/princip/ringus/global/interceptor/SessionInterceptor.java
@@ -1,25 +1,39 @@
 package es.princip.ringus.global.interceptor;
 
 import es.princip.ringus.domain.exception.MemberErrorCode;
+import es.princip.ringus.global.annotation.SessionCheck;
 import es.princip.ringus.global.exception.CustomRuntimeException;
 import es.princip.ringus.global.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Component
 public class SessionInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler){
+        if(isCheckSession(handler)){
+            vaildateSession(request, response);
+        }
+        return true;
+    }
+
+    private boolean isCheckSession(Object handler){
+        return handler instanceof HandlerMethod handlerMethod && handlerMethod.hasMethodAnnotation(SessionCheck.class);
+    }
+
+    private void vaildateSession(HttpServletRequest request, HttpServletResponse response){
         HttpSession session = request.getSession(false);
+
         if(session == null || session.getAttribute("memberId") == null){
             throw new CustomRuntimeException(MemberErrorCode.SESSION_EXPIRED);
         }
+
         System.out.println("[Session Interceptor] : Interceptor 실행, 세션 유효, 멤버 ID: " + session.getAttribute("memberId"));
         CookieUtil.addSessionCookie(response, session.getId());
         request.setAttribute("memberId", session.getAttribute("memberId"));
-        return true;
     }
 }

--- a/src/main/java/es/princip/ringus/infra/config/WebConfig.java
+++ b/src/main/java/es/princip/ringus/infra/config/WebConfig.java
@@ -24,13 +24,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(sessionInterceptor)
-                .excludePathPatterns("/auth/**")
-                .excludePathPatterns("/service-terms")
-                .excludePathPatterns("/swagger-ui/**")
-                .excludePathPatterns("/v3/api-docs/**")
-                .excludePathPatterns("/swagger-resources/**")
-                .excludePathPatterns("/webjars/**");
+        registry.addInterceptor(sessionInterceptor);
     }
 
     @Override

--- a/src/main/java/es/princip/ringus/presentation/member/MemberController.java
+++ b/src/main/java/es/princip/ringus/presentation/member/MemberController.java
@@ -1,6 +1,7 @@
 package es.princip.ringus.presentation.member;
 
 import es.princip.ringus.application.member.service.MemberService;
+import es.princip.ringus.global.annotation.SessionCheck;
 import es.princip.ringus.global.annotation.SessionMemberId;
 import es.princip.ringus.global.util.ApiResponseWrapper;
 import es.princip.ringus.presentation.member.dto.MemberResponse;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
+    @SessionCheck
     @GetMapping("/me")
     public ResponseEntity<ApiResponseWrapper<MemberResponse>> getMember(@SessionMemberId Long memberId){
 
@@ -25,6 +27,7 @@ public class MemberController {
         return ResponseEntity.ok(ApiResponseWrapper.success(HttpStatus.OK, "성공", response));
     }
 
+    @SessionCheck
     @GetMapping("/check-session")
     public ResponseEntity<ApiResponseWrapper<Void>> checkSession(){
 

--- a/src/main/java/es/princip/ringus/presentation/mentee/MenteeController.java
+++ b/src/main/java/es/princip/ringus/presentation/mentee/MenteeController.java
@@ -1,6 +1,7 @@
 package es.princip.ringus.presentation.mentee;
 
 import es.princip.ringus.application.mentee.service.MenteeService;
+import es.princip.ringus.global.annotation.SessionCheck;
 import es.princip.ringus.global.annotation.SessionMemberId;
 import es.princip.ringus.global.util.ApiResponseWrapper;
 import es.princip.ringus.presentation.mentee.dto.*;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class MenteeController implements MenteeControllerDocs{
     private final MenteeService menteeService;
 
+    @SessionCheck
     @PostMapping
     public ResponseEntity<ApiResponseWrapper<MenteeResponse>> create(
             @SessionMemberId Long memberId,
@@ -25,6 +27,7 @@ public class MenteeController implements MenteeControllerDocs{
         return ResponseEntity.ok(ApiResponseWrapper.success(HttpStatus.OK, "성공", response));
     }
 
+    @SessionCheck
     @PutMapping
     public ResponseEntity<ApiResponseWrapper<EditMenteeResponse>> update(
             @SessionMemberId Long memberId,

--- a/src/main/java/es/princip/ringus/presentation/mentor/MentorController.java
+++ b/src/main/java/es/princip/ringus/presentation/mentor/MentorController.java
@@ -1,6 +1,7 @@
 package es.princip.ringus.presentation.mentor;
 
 import es.princip.ringus.application.mentor.service.MentorService;
+import es.princip.ringus.global.annotation.SessionCheck;
 import es.princip.ringus.global.annotation.SessionMemberId;
 import es.princip.ringus.global.util.ApiResponseWrapper;
 import es.princip.ringus.presentation.mentor.dto.*;
@@ -17,6 +18,7 @@ public class MentorController implements MentorControllerDocs{
 
     private final MentorService mentorService;
 
+    @SessionCheck
     @PostMapping
     public ResponseEntity<ApiResponseWrapper<MentorResponse>> create(
             @SessionMemberId Long memberId,
@@ -25,6 +27,7 @@ public class MentorController implements MentorControllerDocs{
         return ResponseEntity.ok(ApiResponseWrapper.success(HttpStatus.OK, "성공", response));
     }
 
+    @SessionCheck
     @PutMapping
     public ResponseEntity<ApiResponseWrapper<EditMentorResponse>> update(
             @SessionMemberId Long memberId,

--- a/src/main/java/es/princip/ringus/presentation/mentoring/MentoringController.java
+++ b/src/main/java/es/princip/ringus/presentation/mentoring/MentoringController.java
@@ -1,6 +1,7 @@
 package es.princip.ringus.presentation.mentoring;
 
 import es.princip.ringus.application.mentoring.MentoringService;
+import es.princip.ringus.global.annotation.SessionCheck;
 import es.princip.ringus.global.annotation.SessionMemberId;
 import es.princip.ringus.global.util.ApiResponseWrapper;
 import es.princip.ringus.presentation.mentoring.dto.CreateMentoringRequest;
@@ -21,6 +22,7 @@ public class MentoringController implements MentoringControllerDocs {
 
     private final MentoringService mentoringService;
 
+    @SessionCheck
     @PostMapping
     public ResponseEntity<ApiResponseWrapper<MentoringResponse>> suggest(
             @SessionMemberId Long memberId,


### PR DESCRIPTION
## ✨ 구현한 기능
- 세션검증을 담당할 어노테이션 기능 구현
- 멘토 프로필 등록, 수정에 어노테이션 적용
- 멘티 프로필 등록, 수정에 어노테이션 적용
- 멘토링 추가 어노테이션 적용
## 📢 논의하고 싶은 내용
- 세션 인터셉터에서 세션 검증을 할 경로를 추가하는 방식에서, @SessionCheck 어노테이션을 사용하는 컨트롤러 메서드에 한해서 인터셉터에 시행되도록 설정했습니다.
## 🎸 기타
- 원래는 스프링에서 제공해주는 AOP를 활용해 검증할 생각이었지만, Resolver 이후에 AOP가 적용되기 때문에 기존 인터셉터를 리팩토링하는 방식으로 설정했습니다.
